### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Hosting via FTP
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/allocazione/allocazione.dev/security/code-scanning/1](https://github.com/allocazione/allocazione.dev/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying a `permissions` block in the workflow, limiting the `GITHUB_TOKEN` to the least privilege required. For most build-and-deploy workflows that only need to read the repository contents, the minimal practical setting is `permissions: contents: read` at the workflow or job level. This documents intent, prevents accidental privilege escalation if org/repo defaults change later, and addresses the CodeQL finding.

For this specific workflow, nothing in the `deploy` job uses `GITHUB_TOKEN` for write operations: it checks out code, sets up Node, installs dependencies, builds, and deploys via FTP using secrets. Therefore, we can safely set `contents: read` as the only permission, applied at the workflow root so it covers all jobs (currently just `deploy`). The best fix is to add a top-level `permissions` block after the `name` and before `on`, without altering any existing steps or functionality. No additional imports or external methods are needed; this is purely a YAML configuration change in `.github/workflows/deploy.yml` around lines 1–7.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration for improved security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->